### PR TITLE
Refactor: Simplify package-specific HTML pages

### DIFF
--- a/goe/index.html
+++ b/goe/index.html
@@ -2,41 +2,11 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <!-- This is the important part for go get -->
     <meta name="go-import" content="go.oease.dev/goe git https://github.com/oeasenet/goe.git">
-
-    <!-- This redirects users visiting in a browser -->
     <meta http-equiv="refresh" content="0; url=https://github.com/oeasenet/goe">
-
-    <title>go.oease.dev/goe - OEASE GOE Framework</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <style>
-        body {
-            font-family: 'Inter', sans-serif;
-        }
-    </style>
+    <title>OEASE GOE Framework</title>
 </head>
-<body class="bg-gray-100 text-gray-900 antialiased flex items-center justify-center min-h-screen">
-    <div class="container mx-auto px-4 py-8 text-center">
-        <div class="bg-white p-8 rounded-lg shadow-lg max-w-lg mx-auto">
-            <h1 class="text-3xl font-bold text-indigo-600 mb-4">OEASE GOE Framework</h1>
-            <p class="text-gray-700 mb-2">
-                You are being redirected to the GOE repository on GitHub.
-            </p>
-            <p class="text-gray-700 mb-6">
-                Import path: <code class="bg-gray-200 text-sm p-1 rounded font-mono">go.oease.dev/goe</code>
-            </p>
-            <a href="https://github.com/oeasenet/goe" class="bg-indigo-500 hover:bg-indigo-600 text-white font-bold py-2 px-4 rounded transition-colors duration-300">
-                Go to Repository
-            </a>
-            <p class="text-xs text-gray-500 mt-6">
-                If you are not redirected automatically, please click the link above.
-            </p>
-        </div>
-        <footer class="text-center mt-8 py-4">
-            <p class="text-gray-600 text-sm">&copy; <script>document.write(new Date().getFullYear())</script> OEASE. Hosted on go.oease.dev.</p>
-        </footer>
-    </div>
+<body>
+    <p>Redirecting to <a href="https://github.com/oeasenet/goe">https://github.com/oeasenet/goe</a>...</p>
 </body>
 </html>

--- a/goe/v2/index.html
+++ b/goe/v2/index.html
@@ -2,41 +2,11 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <!-- This is the important part for go get -->
     <meta name="go-import" content="go.oease.dev/goe/v2 git https://github.com/oeasenet/goe.git">
-
-    <!-- This redirects users visiting in a browser -->
     <meta http-equiv="refresh" content="0; url=https://github.com/oeasenet/goe/tree/v2">
-
-    <title>go.oease.dev/goe/v2 - OEASE GOE Framework v2</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <style>
-        body {
-            font-family: 'Inter', sans-serif;
-        }
-    </style>
+    <title>OEASE GOE Framework v2</title>
 </head>
-<body class="bg-gray-100 text-gray-900 antialiased flex items-center justify-center min-h-screen">
-    <div class="container mx-auto px-4 py-8 text-center">
-        <div class="bg-white p-8 rounded-lg shadow-lg max-w-lg mx-auto">
-            <h1 class="text-3xl font-bold text-indigo-600 mb-4">OEASE GOE Framework v2</h1>
-            <p class="text-gray-700 mb-2">
-                You are being redirected to the GOE v2 repository on GitHub.
-            </p>
-            <p class="text-gray-700 mb-6">
-                Import path: <code class="bg-gray-200 text-sm p-1 rounded font-mono">go.oease.dev/goe/v2</code>
-            </p>
-            <a href="https://github.com/oeasenet/goe/tree/v2" class="bg-indigo-500 hover:bg-indigo-600 text-white font-bold py-2 px-4 rounded transition-colors duration-300">
-                Go to Repository (v2)
-            </a>
-            <p class="text-xs text-gray-500 mt-6">
-                If you are not redirected automatically, please click the link above.
-            </p>
-        </div>
-        <footer class="text-center mt-8 py-4">
-            <p class="text-gray-600 text-sm">&copy; <script>document.write(new Date().getFullYear())</script> OEASE. Hosted on go.oease.dev.</p>
-        </footer>
-    </div>
+<body>
+    <p>Redirecting to <a href="https://github.com/oeasenet/goe/tree/v2">https://github.com/oeasenet/goe/tree/v2</a>...</p>
 </body>
 </html>

--- a/omgo/index.html
+++ b/omgo/index.html
@@ -2,41 +2,11 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <!-- This is the important part for go get -->
     <meta name="go-import" content="go.oease.dev/omgo git https://github.com/oeasenet/omgo.git">
-
-    <!-- This redirects users visiting in a browser -->
     <meta http-equiv="refresh" content="0; url=https://github.com/oeasenet/omgo">
-
-    <title>go.oease.dev/omgo - OEASE OMGO Module</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <style>
-        body {
-            font-family: 'Inter', sans-serif;
-        }
-    </style>
+    <title>OEASE OMGO Module</title>
 </head>
-<body class="bg-gray-100 text-gray-900 antialiased flex items-center justify-center min-h-screen">
-    <div class="container mx-auto px-4 py-8 text-center">
-        <div class="bg-white p-8 rounded-lg shadow-lg max-w-lg mx-auto">
-            <h1 class="text-3xl font-bold text-indigo-600 mb-4">OEASE OMGO Module</h1>
-            <p class="text-gray-700 mb-2">
-                You are being redirected to the OMGO repository on GitHub.
-            </p>
-            <p class="text-gray-700 mb-6">
-                Import path: <code class="bg-gray-200 text-sm p-1 rounded font-mono">go.oease.dev/omgo</code>
-            </p>
-            <a href="https://github.com/oeasenet/omgo" class="bg-indigo-500 hover:bg-indigo-600 text-white font-bold py-2 px-4 rounded transition-colors duration-300">
-                Go to Repository
-            </a>
-            <p class="text-xs text-gray-500 mt-6">
-                If you are not redirected automatically, please click the link above.
-            </p>
-        </div>
-        <footer class="text-center mt-8 py-4">
-            <p class="text-gray-600 text-sm">&copy; <script>document.write(new Date().getFullYear())</script> OEASE. Hosted on go.oease.dev.</p>
-        </footer>
-    </div>
+<body>
+    <p>Redirecting to <a href="https://github.com/oeasenet/omgo">https://github.com/oeasenet/omgo</a>...</p>
 </body>
 </html>


### PR DESCRIPTION
Based on your feedback, this commit reverts the individual package pages (`goe/index.html`, `goe/v2/index.html`, `omgo/index.html`) to their minimal versions.

These pages now solely focus on:
1.  The `go-import` meta tag for `go get` functionality.
2.  A simple HTML meta refresh and a link for browser redirection to the corresponding GitHub repository/branch.

The main `index.html` (root) retains its Tailwind CSS styling and serves as the primary, user-friendly landing page listing all available modules. This change makes the individual package definitions easier to maintain while ensuring `go get` continues to work correctly.